### PR TITLE
add import to __init__

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .iso8601 import *


### PR DESCRIPTION
Hi,

First: thanks for the useful module! (That does ONE thing and doesn't try to parse something out of invalid strings)

This PR adds an import to the `__init__.py`, making the functions in the iso8601 submodule directly available Since there are no other submodules, a user importing it as a module certainly wants to access iso8601.py and not another file.

Example: I included iso8601 in my module in a folder`mypackage/contrib/iso8601/...` and without this import I need `import .contrib.iso8601.iso8601` to reach the parse function, instead of `import.contrib.iso8601`.

Alternatively one could only import parse and the TimeZone class
